### PR TITLE
Account for no event.target and setting value to event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ export default function useInputDebounce(
 ) {
   const [value, setValue] = useState(initial);
   const [onChange] = useState(() => e => {
-    const value = e && e.target ? e.target.value : e;
-    setValue(value || "");
+    const value = e && e.target ? e.target.value : undefined;
+    if (typeof value === "string") setValue(value || "");
   });
 
   useEffect(() => {


### PR DESCRIPTION
Not sure about this, but found it strange while writing the tests.  In the case that you have an event, but no event.target (I'm not sure this could ever even happen), you would be setting value to be the event object.  In turn this would be returned to the users input and set the value of their input to the event object.  Being that value on an input should always be a string, I came up with this as a fix. 